### PR TITLE
Use Redis to generate sequential ids

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ jobs:
       BUNDLE_GEMFILE: ${{ github.workspace }}/gemfiles/${{ matrix.gemfile }}.gemfile
       BUNDLE_PATH_RELATIVE_TO_CWD: true
 
+    services:
+      redis:
+        image: redis
+        ports: ['6379:6379']
+
     steps:
       - uses: actions/checkout@master
 
@@ -36,9 +41,7 @@ jobs:
         env:
           DATABASE_URL: "sqlite3:test"
           RAILS_ENV: test
-        run: |
-          bundle exec rails db:test:prepare
-          bundle exec rails test
+        run: bundle exec appraisal rake test
 
   postgres:
     runs-on: ubuntu-latest
@@ -59,6 +62,9 @@ jobs:
           POSTGRES_PASSWORD: password
           POSTGRES_DB: test
         ports: ['5432:5432']
+      redis:
+        image: redis
+        ports: ['6379:6379']
 
     steps:
       - uses: actions/checkout@master
@@ -77,6 +83,4 @@ jobs:
         env:
           DATABASE_URL: postgres://postgres:password@localhost:5432/test
           RAILS_ENV: test
-        run: |
-          bundle exec rails db:test:prepare
-          bundle exec rails test
+        run: bundle exec appraisal rake test

--- a/gemfiles/rails_7.gemfile.lock
+++ b/gemfiles/rails_7.gemfile.lock
@@ -4,6 +4,7 @@ PATH
     sequenced (4.0.0)
       activerecord (>= 3.0)
       activesupport (>= 3.0)
+      redis (>= 5.4)
 
 GEM
   remote: https://rubygems.org/
@@ -204,6 +205,10 @@ GEM
     rake (13.2.1)
     rdoc (6.13.0)
       psych (>= 4.0.0)
+    redis (5.4.0)
+      redis-client (>= 0.22.0)
+    redis-client (0.24.0)
+      connection_pool
     regexp_parser (2.10.0)
     reline (0.6.0)
       io-console (~> 0.5)

--- a/sequenced.gemspec
+++ b/sequenced.gemspec
@@ -15,5 +15,6 @@ Gem::Specification.new do |s|
 
   s.add_dependency "activesupport", ">= 3.0"
   s.add_dependency "activerecord", ">= 3.0"
-  s.add_development_dependency "rails", ">= 3.1"
+  s.add_dependency "redis", ">= 5.4"
+  s.add_development_dependency "rails", ">= 7.1"
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -16,3 +16,13 @@ end
 
 # Load support files
 Dir["#{File.dirname(__FILE__)}/support/**/*.rb"].sort.each { |f| require f }
+module ResetRedisHelper
+  def setup
+    super
+    Sequenced::Generator.default_redis_client.flushdb
+  end
+end
+
+class Minitest::Test
+  include ResetRedisHelper
+end


### PR DESCRIPTION
- Uses redis to increment sequential ids
- Need to review tests to confirm they actually test redis implementation and not just falling back to pg locks
- Refactor redis client configuration


This pull request introduces Redis integration to the `Sequenced` gem for managing sequence generation, along with some refactoring and dependency updates. The most important changes include adding Redis as a dependency, refactoring the sequence generation logic to use Redis, and updating the test setup to include Redis.

### Integration of Redis for sequence generation:

* [`lib/sequenced/generator.rb`](diffhunk://#diff-a438a3a3b239aab7a509a6a11fb45b513cfa04ca4c95af8ac5ae16cd08155665R1): Added Redis client setup and refactored sequence generation methods to use Redis for storing and incrementing sequence values. [[1]](diffhunk://#diff-a438a3a3b239aab7a509a6a11fb45b513cfa04ca4c95af8ac5ae16cd08155665R1) [[2]](diffhunk://#diff-a438a3a3b239aab7a509a6a11fb45b513cfa04ca4c95af8ac5ae16cd08155665L15-R16) [[3]](diffhunk://#diff-a438a3a3b239aab7a509a6a11fb45b513cfa04ca4c95af8ac5ae16cd08155665L24-R59) [[4]](diffhunk://#diff-a438a3a3b239aab7a509a6a11fb45b513cfa04ca4c95af8ac5ae16cd08155665R93-R105)
* [`sequenced.gemspec`](diffhunk://#diff-8692cb7dcab1b3a5326cad1ba58f6b28a047491bb15e2b82a89d3598cb2872f5L18-R19): Added `redis` as a dependency and updated the development dependency for `rails`.

### Test setup updates:

* [`test/test_helper.rb`](diffhunk://#diff-ba37813ca277c227a74a372479b7b05b7f3ff085d890ab708f80d62573efdb7aR19-R29): Added a module to reset Redis before each test to ensure a clean state.