### PR TITLE
drop expiration on key set

### DIFF
--- a/lib/sequenced/generator.rb
+++ b/lib/sequenced/generator.rb
@@ -62,7 +62,7 @@ module Sequenced
       start_at = self.start_at.respond_to?(:call) ? self.start_at.call(record) : self.start_at
       last_id = find_last_record&.send(column) || 0
 
-      redis_client.set(sequence_key, max(last_id, start_at - 1), nx: true, ex: 86400)
+      redis_client.set(sequence_key, max(last_id, start_at - 1), nx: true)
     end
 
     def next_id_in_sequence(increment:)


### PR DESCRIPTION
Setting an expiration causes falling back to the expensive pg table lock query. No need to expire these keys.

This pull request modifies the behavior of the `prepare_next_id` method in the `lib/sequenced/generator.rb` file to simplify the Redis key-setting logic by removing the expiration time.

### Changes to Redis key-setting logic:

* [`lib/sequenced/generator.rb`](diffhunk://#diff-a438a3a3b239aab7a509a6a11fb45b513cfa04ca4c95af8ac5ae16cd08155665L65-R65): Removed the `ex: 86400` option from the `redis_client.set` method call in `prepare_next_id`, eliminating the expiration time for the Redis key.